### PR TITLE
Faraday doesn’t have a timed_out? method so handle timeouts in the Faraday way

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,8 @@
 = Simple SDK Builder
 
+== 2.1.1
+* Fix broken timeout logic
+
 == 2.1.0
 * replace Typheous with Faraday, replace code with status
 * update ruby version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple_sdk_builder (2.1.0)
+    simple_sdk_builder (2.1.1)
       activemodel (>= 4.2, < 6)
       activesupport (>= 4.2, < 6)
       faraday (~> 0.13)

--- a/lib/simple_sdk_builder/version.rb
+++ b/lib/simple_sdk_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleSDKBuilder
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -5,17 +5,12 @@ RSpec.describe SimpleSDKBuilder::Base do
     attr_accessor :timed_out, :status, :body
 
     def initialize(options = {}) # rubocop:disable Style/OptionHash
-      self.timed_out = false
       self.status = 200
       self.body = %({"value":"it worked!"})
 
       options.each do |key, value|
         public_send("#{key}=", value)
       end
-    end
-
-    def timed_out?
-      @timed_out
     end
   end
 
@@ -69,10 +64,13 @@ RSpec.describe SimpleSDKBuilder::Base do
         expect { subject.check_response(MockResponse.new(status: 301)) }
           .to raise_error(unknown_error)
       end
+    end
 
-      it 'should raise a timeout_error upon a timeout' do
-        expect { subject.check_response(MockResponse.new(timed_out: true, status: nil)) }
-          .to raise_error(timeout_error)
+    context 'when the request times out' do
+      before { base_class.config timeout: 0.00001, service_url: 'https://www.stashrewards.com' }
+
+      it 'raises the right error' do
+        expect { subject.json_request }.to raise_error(timeout_error, 'execution expired')
       end
     end
 

--- a/spec/support/simplecov_setup.rb
+++ b/spec/support/simplecov_setup.rb
@@ -9,5 +9,5 @@ SimpleCov.start do
   add_filter 'spec/'
   add_filter 'lib/simple_sdk_builder/version'
 
-  minimum_coverage 59
+  minimum_coverage 62
 end


### PR DESCRIPTION
fixes a bug in version 2.1.0